### PR TITLE
Make Sparse Time Functions Julian

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -353,13 +353,12 @@ end
     end
 end
 
-@testset "Sparse Inject" begin
+@testset "Sparse Inject and Interpolate" begin
     dt = 0.01
     nt = 101
     time_range = 0.0f0:dt:dt*(nt-1)
 
     grid = Grid(shape=(5,5),origin=(0.,0.),extent=(1.,1.))
-
     p = TimeFunction(grid=grid,space_order=8,time_order=2,name="p")
     y,x,t = dimensions(p)
     dt = step(time_range)
@@ -368,16 +367,26 @@ end
 
     src = SparseTimeFunction(name="src", grid=grid, npoint=1, nt=nt)
     @test typeof(dimensions(src)[1]) == Dimension
-
+    coords =  [0.5; 0]
     src_coords = coordinates(src)
-    src_coords .= [0.5; 0.5]
+    src_coords .= coords
     src_data = data(src)
-    src_data .= reshape(1e3*Base.sin.(time_range .* (3*pi/2)),1,:)
+    src_data .= reshape(1e3*Base.sin.(time_range .* (3*pi/2)),:,1)
     pupdate = Eq(forward(p),1+p)
     src_term = inject(src; field=forward(p), expr=src*spacing(t)^2)
-    op = Operator([pupdate,src_term],name="SparseInject", subs=smap)
-    apply(op)
-    @test data(p)[3,3,end-1] ≈ (nt-1) + sum(src_data[1:end-1])*dt^2
+
+    rec = SparseTimeFunction(name="rec", grid=grid, npoint=2, nt=nt)
+    rec_coords = coordinates(rec)
+    rec_coords[:,1] .= coords
+    rec_coords[:,2] .= reverse(coords)
+    rec_term = interpolate(rec, expr=p)
+
+    op = Operator([pupdate,src_term,rec_term],name="SparseInjectInterp", subs=smap)
+    apply(op,time_M=nt-1)
+    @test data(p)[3,1,end-1] ≈ (nt-1) + sum(src_data[1:end-1])*dt^2
+    @test data(rec)[end,1] ≈ (nt-1) + sum(src_data[1:end-1])*dt^2
+    @test data(rec)[end,2] ≈ (nt-1)
+    
 end
 
 @testset "Left and Right Derivatives" begin


### PR DESCRIPTION
Make coordinates for sparse time functions julian (fast to slow)
Make the arrays for sparse time functions be (time, position index) so looping over the slow index would be akin to looping over receiver or source, rather than looping through time indexes in a trace