### PR TITLE
fix copy! and convert methods for SparseTimeFunction's

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -4,6 +4,7 @@ authors = ["Sam Kaplan <Sam.Kaplan@chevron.com>"]
 version = "0.1.0"
 
 [deps]
+LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 MPI = "da04e1cc-30fd-572f-bb4f-1f8673147195"
 PyCall = "438e738f-606a-5dbb-bf0a-cddfbfd45ab0"
 Strided = "5e0ebb24-38b0-5f93-81fe-25c709ecae67"


### PR DESCRIPTION
I'm not sure if this is the best solution.  But these changes allow for the `copy!` and `convert` methods to work with the transposed data that is now returned from calls to `data(x::SparseTimeFunction)`  when running with MPI.