### PR TITLE
Mpiruntests

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -27,4 +27,4 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 benchmark = ["PkgBenchmark"]
 build = ["Conda"]
 demo = ["MPIClusterManagers"]
-test = ["Distributed", "MPIClusterManagers", "Random", "Test"]
+test = ["Random", "Test"]

--- a/src/Devito.jl
+++ b/src/Devito.jl
@@ -213,6 +213,14 @@ function Base.convert(::Type{Array}, x::DevitoMPITimeArray{T,N}) where {T,N}
     __x
 end
 
+function Base.copy!(dst::Union{DevitoMPIAbstractArray,Transpose{<:Number,<:DevitoMPIAbstractArray}}, src::AbstractArray)
+    if MPI.Comm_rank(MPI.COMM_WORLD) == 0
+        axes(dst) == axes(src) || throw(ArgumentError(
+            "arrays must have the same axes for copy! (consider using `copyto!`)"))
+    end
+    copyto!(dst, src)
+end
+
 function Base.copyto!(dst::DevitoMPITimeArray{T,N}, src::AbstractArray{T,N}) where {T,N}
     MPI.Initialized() || MPI.Init()
 

--- a/test/mpitests.jl
+++ b/test/mpitests.jl
@@ -1,480 +1,478 @@
-using Distributed, MPIClusterManagers
 
-manager = MPIWorkerManager(2)
-addprocs(manager)
+using Devito, LinearAlgebra, MPI, Random, Strided, Test
 
-@everywhere using Devito, LinearAlgebra, MPI, Random, Strided, Test
+MPI.Init()
+configuration!("log-level", "DEBUG")
+configuration!("language", "openmp")
+configuration!("mpi", true)
 
-@mpi_do manager begin
-    configuration!("log-level", "DEBUG")
-    configuration!("language", "openmp")
-    configuration!("mpi", true)
-
-    @testset "DevitoMPIArray, fill!, with halo, n=$n" for n in ( (11,10), (12,11,10) )
-        grid = Grid(shape=n, dtype=Float32)
-        b = Devito.Function(name="b", grid=grid, space_order=2)
-        b_data = data_with_halo(b)
-        @test isa(b_data, Devito.DevitoMPIArray{Float32,length(n)})
-        if length(n) == 2
-            @test size(b_data) == (15,14)
-        else
-            @test size(b_data) == (16,15,14)
-        end
-        b_data .= 3.14f0
-
-        for rnk in 0:1
-            if MPI.Comm_rank(MPI.COMM_WORLD) == rnk
-                if length(n) == 2
-                    @test parent(b_data) ≈ 3.14*ones(Float32, 15, 7)
-                else
-                    @test parent(b_data) ≈ 3.14*ones(Float32, 16, 15, 7)
-                end
-                @test isa(parent(b_data), StridedView)
-            end
-            MPI.Barrier(MPI.COMM_WORLD)
-        end
+@testset "DevitoMPIArray, fill!, with halo, n=$n" for n in ( (11,10), (12,11,10) )
+    grid = Grid(shape=n, dtype=Float32)
+    b = Devito.Function(name="b", grid=grid, space_order=2)
+    b_data = data_with_halo(b)
+    @test isa(b_data, Devito.DevitoMPIArray{Float32,length(n)})
+    if length(n) == 2
+        @test size(b_data) == (15,14)
+    else
+        @test size(b_data) == (16,15,14)
     end
+    b_data .= 3.14f0
 
-    @testset "DevitoMPIArray, fill!, no halo, n=$n" for n in ( (11,10), (12,11,10) )
-        grid = Grid(shape=n, dtype=Float32)
-        b = Devito.Function(name="b", grid=grid, space_order=2)
-        b_data = data(b)
-        @test isa(b_data, Devito.DevitoMPIArray{Float32,length(n)})
-        @test size(b_data) == n
-        b_data .= 3.14f0
-
-        b_data_test = data(b)
-
-        for rnk in 0:1
-            if MPI.Comm_rank(MPI.COMM_WORLD) == rnk
-                if length(n) == 2
-                    @test parent(b_data_test) ≈ 3.14*ones(Float32, 11, 5)
-                else
-                    @test parent(b_data_test) ≈ 3.14*ones(Float32, 12, 11, 5)
-                end
-                @test isa(parent(b_data_test), StridedView)
+    for rnk in 0:1
+        if MPI.Comm_rank(MPI.COMM_WORLD) == rnk
+            if length(n) == 2
+                @test parent(b_data) ≈ 3.14*ones(Float32, 15, 7)
+            else
+                @test parent(b_data) ≈ 3.14*ones(Float32, 16, 15, 7)
             end
-            MPI.Barrier(MPI.COMM_WORLD)
+            @test isa(parent(b_data), StridedView)
         end
+        MPI.Barrier(MPI.COMM_WORLD)
     end
+end
 
-    @testset "DevitoMPIArray, copy!, inhalo, n=$n" for n in ( (11,10), (12,11,10) )
-        grid = Grid(shape=n, dtype=Float32)
-        b = Devito.Function(name="b", grid=grid, space_order=2)
-        b_data = data_with_inhalo(b)
-        @test isa(b_data, Devito.DevitoMPIArray{Float32,length(n)})
+@testset "DevitoMPIArray, fill!, no halo, n=$n" for n in ( (11,10), (12,11,10) )
+    grid = Grid(shape=n, dtype=Float32)
+    b = Devito.Function(name="b", grid=grid, space_order=2)
+    b_data = data(b)
+    @test isa(b_data, Devito.DevitoMPIArray{Float32,length(n)})
+    @test size(b_data) == n
+    b_data .= 3.14f0
 
-        _n = length(n) == 2 ? (15,18) : (16,15,18)
-        @show n, _n
+    b_data_test = data(b)
 
-        @test size(b_data) == _n
-
-        b_data_test = zeros(Float32, _n)
-        if MPI.Comm_rank(MPI.COMM_WORLD) == 0
-            b_data_test = reshape(Float32[1:prod(_n);], _n)
+    for rnk in 0:1
+        if MPI.Comm_rank(MPI.COMM_WORLD) == rnk
+            if length(n) == 2
+                @test parent(b_data_test) ≈ 3.14*ones(Float32, 11, 5)
+            else
+                @test parent(b_data_test) ≈ 3.14*ones(Float32, 12, 11, 5)
+            end
+            @test isa(parent(b_data_test), StridedView)
         end
-        copy!(b_data, b_data_test)
+        MPI.Barrier(MPI.COMM_WORLD)
+    end
+end
+
+@testset "DevitoMPIArray, copy!, inhalo, n=$n" for n in ( (11,10), (12,11,10) )
+    grid = Grid(shape=n, dtype=Float32)
+    b = Devito.Function(name="b", grid=grid, space_order=2)
+    b_data = data_with_inhalo(b)
+    @test isa(b_data, Devito.DevitoMPIArray{Float32,length(n)})
+
+    _n = length(n) == 2 ? (15,18) : (16,15,18)
+    @show n, _n
+
+    @test size(b_data) == _n
+
+    b_data_test = zeros(Float32, _n)
+    if MPI.Comm_rank(MPI.COMM_WORLD) == 0
         b_data_test = reshape(Float32[1:prod(_n);], _n)
+    end
+    copy!(b_data, b_data_test)
+    b_data_test = reshape(Float32[1:prod(_n);], _n)
 
-        for rnk in 0:1
-            if MPI.Comm_rank(MPI.COMM_WORLD) == rnk
-                if rnk == 0
-                    if length(n) == 2
-                        @test parent(b_data) ≈ b_data_test[:,1:9]
-                    else
-                        @test parent(b_data) ≈ b_data_test[:,:,1:9]
-                    end
-                elseif rnk == 1
-                    if length(n) == 2
-                        @test parent(b_data) ≈ b_data_test[:,10:18]
-                    else
-                        @test parent(b_data) ≈ b_data_test[:,:,10:18]
-                    end
+    for rnk in 0:1
+        if MPI.Comm_rank(MPI.COMM_WORLD) == rnk
+            if rnk == 0
+                if length(n) == 2
+                    @test parent(b_data) ≈ b_data_test[:,1:9]
+                else
+                    @test parent(b_data) ≈ b_data_test[:,:,1:9]
+                end
+            elseif rnk == 1
+                if length(n) == 2
+                    @test parent(b_data) ≈ b_data_test[:,10:18]
+                else
+                    @test parent(b_data) ≈ b_data_test[:,:,10:18]
                 end
             end
-            MPI.Barrier(MPI.COMM_WORLD)
         end
+        MPI.Barrier(MPI.COMM_WORLD)
     end
+end
 
-    @testset "DevitoMPIArray, copy!, halo, n=$n" for n in ( (11,10), (12,11,10) )
-        grid = Grid(shape=n, dtype=Float32)
-        b = Devito.Function(name="b", grid=grid, space_order=2)
-        b_data = data_with_halo(b)
-        @test isa(b_data, Devito.DevitoMPIArray{Float32,length(n)})
+@testset "DevitoMPIArray, copy!, halo, n=$n" for n in ( (11,10), (12,11,10) )
+    grid = Grid(shape=n, dtype=Float32)
+    b = Devito.Function(name="b", grid=grid, space_order=2)
+    b_data = data_with_halo(b)
+    @test isa(b_data, Devito.DevitoMPIArray{Float32,length(n)})
 
-        _n = length(n) == 2 ? (15,14) : (16,15,14)
+    _n = length(n) == 2 ? (15,14) : (16,15,14)
 
-        @test size(b_data) == _n
+    @test size(b_data) == _n
 
-        b_data_test = zeros(Float32, _n)
-        if MPI.Comm_rank(MPI.COMM_WORLD) == 0
-            b_data_test = reshape(Float32[1:prod(_n);], _n)
-        end
-        copy!(b_data, b_data_test)
+    b_data_test = zeros(Float32, _n)
+    if MPI.Comm_rank(MPI.COMM_WORLD) == 0
         b_data_test = reshape(Float32[1:prod(_n);], _n)
-
-        for rnk in 0:1
-            if MPI.Comm_rank(MPI.COMM_WORLD) == rnk
-                if rnk == 0
-                    if length(n) == 2
-                        @test parent(b_data) ≈ b_data_test[:,1:7]
-                    else
-                        @test parent(b_data) ≈ b_data_test[:,:,1:7]
-                    end
-                end
-                if rnk == 1
-                    if length(n) == 2
-                        @test parent(b_data) ≈ b_data_test[:,8:14]
-                    else
-                        @test parent(b_data) ≈ b_data_test[:,:,8:14]
-                    end
-                end
-                @test isa(parent(b_data), StridedView)
-            end
-            MPI.Barrier(MPI.COMM_WORLD)
-        end
     end
+    copy!(b_data, b_data_test)
+    b_data_test = reshape(Float32[1:prod(_n);], _n)
 
-    @testset "DevitoMPIArray, copy!, no halo, n=$n" for n in ( (11,10), (12,11,10) )
-        grid = Grid(shape=n, dtype=Float32)
-        b = Devito.Function(name="b", grid=grid, space_order=2)
-        b_data = data(b)
-        @test isa(b_data, Devito.DevitoMPIArray{Float32,length(n)})
-        @test size(b_data) == n
-        b_data_test = zeros(Float32, n)
-        if MPI.Comm_rank(MPI.COMM_WORLD) == 0
-            b_data_test = reshape(Float32[1:prod(n);], n)
+    for rnk in 0:1
+        if MPI.Comm_rank(MPI.COMM_WORLD) == rnk
+            if rnk == 0
+                if length(n) == 2
+                    @test parent(b_data) ≈ b_data_test[:,1:7]
+                else
+                    @test parent(b_data) ≈ b_data_test[:,:,1:7]
+                end
+            end
+            if rnk == 1
+                if length(n) == 2
+                    @test parent(b_data) ≈ b_data_test[:,8:14]
+                else
+                    @test parent(b_data) ≈ b_data_test[:,:,8:14]
+                end
+            end
+            @test isa(parent(b_data), StridedView)
         end
-        copy!(b_data, b_data_test)
-        _b_data = data(b)
+        MPI.Barrier(MPI.COMM_WORLD)
+    end
+end
+
+@testset "DevitoMPIArray, copy!, no halo, n=$n" for n in ( (11,10), (12,11,10) )
+    grid = Grid(shape=n, dtype=Float32)
+    b = Devito.Function(name="b", grid=grid, space_order=2)
+    b_data = data(b)
+    @test isa(b_data, Devito.DevitoMPIArray{Float32,length(n)})
+    @test size(b_data) == n
+    b_data_test = zeros(Float32, n)
+    if MPI.Comm_rank(MPI.COMM_WORLD) == 0
         b_data_test = reshape(Float32[1:prod(n);], n)
+    end
+    copy!(b_data, b_data_test)
+    _b_data = data(b)
+    b_data_test = reshape(Float32[1:prod(n);], n)
 
-        for rnk in 0:1
-            if MPI.Comm_rank(MPI.COMM_WORLD) == rnk
-                if rnk == 0
-                    if length(n) == 2
-                        @test parent(_b_data) ≈ b_data_test[:,1:5]
-                        @test parent(b_data) ≈ b_data_test[:,1:5]
-                    else
-                        @test parent(_b_data) ≈ b_data_test[:,:,1:5]
-                        @test parent(b_data) ≈ b_data_test[:,:,1:5]
-                    end
-                    @test isa(parent(_b_data), StridedView)
+    for rnk in 0:1
+        if MPI.Comm_rank(MPI.COMM_WORLD) == rnk
+            if rnk == 0
+                if length(n) == 2
+                    @test parent(_b_data) ≈ b_data_test[:,1:5]
+                    @test parent(b_data) ≈ b_data_test[:,1:5]
+                else
+                    @test parent(_b_data) ≈ b_data_test[:,:,1:5]
+                    @test parent(b_data) ≈ b_data_test[:,:,1:5]
                 end
-                if rnk == 1
-                    if length(n) == 2
-                        @test parent(_b_data) ≈ b_data_test[:,6:10]
-                        @test parent(b_data) ≈ b_data_test[:,6:10]
-                    else
-                        @test parent(_b_data) ≈ b_data_test[:,:,6:10]
-                        @test parent(b_data) ≈ b_data_test[:,:,6:10]
-                    end
-                    @test isa(parent(_b_data), StridedView)
+                @test isa(parent(_b_data), StridedView)
+            end
+            if rnk == 1
+                if length(n) == 2
+                    @test parent(_b_data) ≈ b_data_test[:,6:10]
+                    @test parent(b_data) ≈ b_data_test[:,6:10]
+                else
+                    @test parent(_b_data) ≈ b_data_test[:,:,6:10]
+                    @test parent(b_data) ≈ b_data_test[:,:,6:10]
                 end
-            end
-            MPI.Barrier(MPI.COMM_WORLD)
-        end
-    end
-
-    @testset "convert data from rank 0 to DevitoMPIArray, then back, inhalo, n=$n" for n in ( (11,10), (12,11,10) )
-        grid = Grid(shape=n, dtype=Float32)
-        b = Devito.Function(name="b", grid=grid, space_order=2)
-        b_data = data_with_inhalo(b)
-
-        _n = length(n) == 2 ? (15,18) : (16,15,18)
-
-        b_data_test = zeros(Float32, _n)
-        if MPI.Comm_rank(MPI.COMM_WORLD) == 0
-            b_data_test .= reshape(Float32[1:prod(_n);], _n)
-        end
-        MPI.Barrier(MPI.COMM_WORLD)
-        copy!(b_data, b_data_test)
-
-        b_data_out = convert(Array, b_data)
-        if MPI.Comm_rank(MPI.COMM_WORLD) == 0
-            @test b_data_out ≈ b_data_test
-        end
-        MPI.Barrier(MPI.COMM_WORLD)
-    end
-
-    @testset "convert data from rank 0 to DevitoMPIArray, then back, halo, n=$n" for n in ( (11,10), (12,11,10) )
-        grid = Grid(shape=n, dtype=Float32)
-        b = Devito.Function(name="b", grid=grid, space_order=2)
-        b_data = data_with_halo(b)
-
-        _n = length(n) == 2 ? (15,14) : (16,15,14)
-
-        b_data_test = zeros(Float32, _n)
-        if MPI.Comm_rank(MPI.COMM_WORLD) == 0
-            b_data_test .= reshape(Float32[1:prod(_n);], _n)
-        end
-        copy!(b_data, b_data_test)
-        _b_data = data_with_halo(b)
-
-        b_data_out = convert(Array, _b_data)
-        if MPI.Comm_rank(MPI.COMM_WORLD) == 0
-            @test b_data_out ≈ b_data_test
-        end
-    end
-
-    @testset "Convert data from rank 0 to DevitoMPIArray then back, no halo, n=$n" for n in ( (11,10), (12,11,10) )
-        grid = Grid(shape=n, dtype=Float32)
-        b = Devito.Function(name="b", grid=grid, space_order=2)
-        b_data = data(b)
-
-        b_data_test = zeros(Float32, n)
-        if MPI.Comm_rank(MPI.COMM_WORLD) == 0
-            b_data_test .= reshape(Float32[1:prod(n);], n)
-        end
-        copy!(b_data, b_data_test)
-        _b_data = data(b)
-
-        b_data_out = convert(Array, _b_data)
-        if MPI.Comm_rank(MPI.COMM_WORLD) == 0
-            @test b_data_out ≈ b_data_test
-        end
-        MPI.Barrier(MPI.COMM_WORLD)
-    end
-
-    @testset "DevitoMPITimeArray, copy!, data, inhalo, n=$n" for n in ( (11,10), (12,11,10))
-        grid = Grid(shape = n, dtype = Float32)
-        b = Devito.Function(name="b", grid=grid, space_order=2)
-        p = TimeFunction(name="p", grid=grid, time_order=2, space_order=2)
-        p_data = data_with_inhalo(p)
-
-        _n = length(n) == 2 ? (15,18,3) : (16,15,18,3)
-        p_data_test = zeros(Float32, _n)
-        if MPI.Comm_rank(MPI.COMM_WORLD) == 0
-            p_data_test .= reshape(Float32[1:prod(_n);], _n)
-        end
-        copy!(p_data, p_data_test)
-        p_data_test .= reshape(Float32[1:prod(_n);], _n)
-
-        p_data_local = parent(p_data)
-        if MPI.Comm_rank(MPI.COMM_WORLD) == 0
-            if length(n) == 2
-                @test p_data_local ≈ p_data_test[:,1:9,:]
-            else
-                @test p_data_local ≈ p_data_test[:,:,1:9,:]
-            end
-        end
-        if MPI.Comm_rank(MPI.COMM_WORLD) == 1
-            if length(n) == 2
-                @test p_data_local ≈ p_data_test[:,10:18,:]
-            else
-                @test p_data_local ≈ p_data_test[:,:,10:18,:]
+                @test isa(parent(_b_data), StridedView)
             end
         end
         MPI.Barrier(MPI.COMM_WORLD)
     end
+end
 
-    @testset "DevitoMPITimeArray, copy!, data, halo, n=$n" for n in ( (11,10), (12,11,10))
-        grid = Grid(shape = n, dtype = Float32)
-        b = Devito.Function(name="b", grid=grid, space_order=2)
-        p = TimeFunction(name="p", grid=grid, time_order=2, space_order=2)
-        p_data = data_with_halo(p)
+@testset "convert data from rank 0 to DevitoMPIArray, then back, inhalo, n=$n" for n in ( (11,10), (12,11,10) )
+    grid = Grid(shape=n, dtype=Float32)
+    b = Devito.Function(name="b", grid=grid, space_order=2)
+    b_data = data_with_inhalo(b)
 
-        _n = length(n) == 2 ? (15,14,3) : (16,15,14,3)
-        p_data_test = zeros(Float32, _n)
-        if MPI.Comm_rank(MPI.COMM_WORLD) == 0
-            p_data_test .= reshape(Float32[1:prod(_n);], _n)
-        end
-        copy!(p_data, p_data_test)
+    _n = length(n) == 2 ? (15,18) : (16,15,18)
+
+    b_data_test = zeros(Float32, _n)
+    if MPI.Comm_rank(MPI.COMM_WORLD) == 0
+        b_data_test .= reshape(Float32[1:prod(_n);], _n)
+    end
+    MPI.Barrier(MPI.COMM_WORLD)
+    copy!(b_data, b_data_test)
+
+    b_data_out = convert(Array, b_data)
+    if MPI.Comm_rank(MPI.COMM_WORLD) == 0
+        @test b_data_out ≈ b_data_test
+    end
+    MPI.Barrier(MPI.COMM_WORLD)
+end
+
+@testset "convert data from rank 0 to DevitoMPIArray, then back, halo, n=$n" for n in ( (11,10), (12,11,10) )
+    grid = Grid(shape=n, dtype=Float32)
+    b = Devito.Function(name="b", grid=grid, space_order=2)
+    b_data = data_with_halo(b)
+
+    _n = length(n) == 2 ? (15,14) : (16,15,14)
+
+    b_data_test = zeros(Float32, _n)
+    if MPI.Comm_rank(MPI.COMM_WORLD) == 0
+        b_data_test .= reshape(Float32[1:prod(_n);], _n)
+    end
+    copy!(b_data, b_data_test)
+    _b_data = data_with_halo(b)
+
+    b_data_out = convert(Array, _b_data)
+    if MPI.Comm_rank(MPI.COMM_WORLD) == 0
+        @test b_data_out ≈ b_data_test
+    end
+end
+
+@testset "Convert data from rank 0 to DevitoMPIArray then back, no halo, n=$n" for n in ( (11,10), (12,11,10) )
+    grid = Grid(shape=n, dtype=Float32)
+    b = Devito.Function(name="b", grid=grid, space_order=2)
+    b_data = data(b)
+
+    b_data_test = zeros(Float32, n)
+    if MPI.Comm_rank(MPI.COMM_WORLD) == 0
+        b_data_test .= reshape(Float32[1:prod(n);], n)
+    end
+    copy!(b_data, b_data_test)
+    _b_data = data(b)
+
+    b_data_out = convert(Array, _b_data)
+    if MPI.Comm_rank(MPI.COMM_WORLD) == 0
+        @test b_data_out ≈ b_data_test
+    end
+    MPI.Barrier(MPI.COMM_WORLD)
+end
+
+@testset "DevitoMPITimeArray, copy!, data, inhalo, n=$n" for n in ( (11,10), (12,11,10))
+    grid = Grid(shape = n, dtype = Float32)
+    b = Devito.Function(name="b", grid=grid, space_order=2)
+    p = TimeFunction(name="p", grid=grid, time_order=2, space_order=2)
+    p_data = data_with_inhalo(p)
+
+    _n = length(n) == 2 ? (15,18,3) : (16,15,18,3)
+    p_data_test = zeros(Float32, _n)
+    if MPI.Comm_rank(MPI.COMM_WORLD) == 0
         p_data_test .= reshape(Float32[1:prod(_n);], _n)
-
-        p_data_local = parent(p_data)
-        if MPI.Comm_rank(MPI.COMM_WORLD) == 0
-            if length(n) == 2
-                @test p_data_local ≈ p_data_test[:,1:7,:]
-            else
-                @test p_data_local ≈ p_data_test[:,:,1:7,:]
-            end
-        end
-        if MPI.Comm_rank(MPI.COMM_WORLD) == 1
-            if length(n) == 2
-                @test p_data_local ≈ p_data_test[:,8:14,:]
-            else
-                @test p_data_local ≈ p_data_test[:,:,8:14,:]
-            end
-        end
-        MPI.Barrier(MPI.COMM_WORLD)
     end
+    copy!(p_data, p_data_test)
+    p_data_test .= reshape(Float32[1:prod(_n);], _n)
 
-    @testset "DevitoMPITimeArray, copy!, data, no halo, n=$n" for n in ( (11,10), (12,11,10))
-        grid = Grid(shape = n, dtype = Float32)
-        b = Devito.Function(name="b", grid=grid, space_order=2)
-        p = TimeFunction(name="p", grid=grid, time_order=2, space_order=2)
-        p_data = data(p)
-
-        _n = length(n) == 2 ? (11,10,3) : (12,11,10,3)
-        p_data_test = zeros(Float32, _n)
-        if MPI.Comm_rank(MPI.COMM_WORLD) == 0
-            p_data_test .= reshape(Float32[1:prod(_n);], _n)
-        end
-        copy!(p_data, p_data_test)
-        p_data_test .= reshape(Float32[1:prod(_n);], _n)
-
-        p_data_local = parent(p_data)
-        if MPI.Comm_rank(MPI.COMM_WORLD) == 0
-            if length(n) == 2
-                @test p_data_local ≈ p_data_test[:,1:5,:]
-            else
-                @test p_data_local ≈ p_data_test[:,:,1:5,:]
-            end
-        end
-        if MPI.Comm_rank(MPI.COMM_WORLD) == 1
-            if length(n) == 2
-                @test p_data_local ≈ p_data_test[:,6:10,:]
-            else
-                @test p_data_local ≈ p_data_test[:,:,6:10,:]
-            end
-        end
-        MPI.Barrier(MPI.COMM_WORLD)
-    end
-
-    @testset "convert data from rank 0 to DevitoMPITimeArray, then back, inhalo, n=$n" for n in ( (11,10), (12,11,10) )
-        grid = Grid(shape = n, dtype = Float32)
-        b = Devito.Function(name="b", grid=grid, space_order=2)
-        p = TimeFunction(name="p", grid=grid, time_order=2, space_order=2)
-        p_data = data_with_inhalo(p)
-
-        _n = length(n) == 2 ? (15,18,3) : (16,15,18,3)
-
-        p_data_test = zeros(Float32, _n)
-        if MPI.Comm_rank(MPI.COMM_WORLD) == 0
-            p_data_test .= reshape(Float32[1:prod(_n);], _n)
-        end
-        copy!(p_data, p_data_test)
-        p_data_test .= reshape(Float32[1:prod(_n);], _n)
-
-        _p_data_test = convert(Array, p_data)
-
-        if MPI.Comm_rank(MPI.COMM_WORLD) == 0
-            @test p_data_test ≈ _p_data_test
-        end
-    end
-
-    @testset "convert data from rank 0 to DevitoMPITimeArray, then back, halo, n=$n" for n in ( (11,10), (12,11,10) )
-        grid = Grid(shape = n, dtype = Float32)
-        b = Devito.Function(name="b", grid=grid, space_order=2)
-        p = TimeFunction(name="p", grid=grid, time_order=2, space_order=2)
-        p_data = data_with_halo(p)
-
-        _n = length(n) == 2 ? (15,14,3) : (16,15,14,3)
-
-        p_data_test = zeros(Float32, _n)
-        if MPI.Comm_rank(MPI.COMM_WORLD) == 0
-            p_data_test .= reshape(Float32[1:prod(_n);], _n)
-        end
-        copy!(p_data, p_data_test)
-        p_data_test .= reshape(Float32[1:prod(_n);], _n)
-
-        _p_data_test = convert(Array, p_data)
-
-        if MPI.Comm_rank(MPI.COMM_WORLD) == 0
-            @test p_data_test ≈ _p_data_test
-        end
-    end
-
-    @testset "convert data from rank 0 to DevitoMPITimeArray, then back, no halo, n=$n" for n in ( (11,10), (12,11,10) )
-        grid = Grid(shape = n, dtype = Float32)
-        b = Devito.Function(name="b", grid=grid, space_order=2)
-        p = TimeFunction(name="p", grid=grid, time_order=2, space_order=2)
-        p_data = data(p)
-
-        _n = length(n) == 2 ? (11,10,3) : (12,11,10,3)
-
-        p_data_test = zeros(Float32, _n)
-        if MPI.Comm_rank(MPI.COMM_WORLD) == 0
-            p_data_test .= reshape(Float32[1:prod(_n);], _n)
-        end
-        copy!(p_data, p_data_test)
-        p_data_test .= reshape(Float32[1:prod(_n);], _n)
-
-        _p_data_test = convert(Array, p_data)
-
-        if MPI.Comm_rank(MPI.COMM_WORLD) == 0
-            @test p_data_test ≈ _p_data_test
-        end
-    end
-
-    @testset "Sparse time function coordinates, n=$n, npoint=$npoint" for n in ( (11,10), (12,11,10) ), npoint in (1, 5, 10)
-        grid = Grid(shape=n, dtype=Float32)
-        stf = SparseTimeFunction(name="stf", npoint=npoint, nt=100, grid=grid)
-        stf_coords = coordinates(stf)
-        @test isa(stf_coords, Devito.DevitoMPIArray)
-        @test size(stf_coords) == (length(n),npoint)
-        x = rand(Float32,length(n),npoint)
-
-        copy!(stf_coords, x)
-
-        _stf_coords = convert(Array,coordinates(stf))
-
-        if MPI.Comm_rank(MPI.COMM_WORLD) == 0
-            @test _stf_coords ≈ x
-        end
-    end
-
-    @testset "Sparse time function, copy!, n=$n, npoint=$npoint" for n in ( (11,10), (12,11,10) ), npoint in (1, 5, 10)
-        grid = Grid(shape=n, dtype=Float32)
-        nt = 100
-        stf = SparseTimeFunction(name="stf", npoint=npoint, nt=nt, grid=grid)
-
-        x = zeros(Float32, nt, npoint)
-        if MPI.Comm_rank(MPI.COMM_WORLD) == 0
-            x .= reshape(Float32[1:prod(nt*npoint);], nt, npoint)
-        end
-        _x = data(stf)
-        copy!(_x, x)
-        x .= reshape(Float32[1:prod(nt*npoint);], nt, npoint)
-
-        if MPI.Comm_rank(MPI.COMM_WORLD) == 0
-            if npoint == 1
-                @test isempty(parent(parent(_x)))
-            elseif npoint == 5
-                @test parent(parent(_x)) ≈ (x[:,1:2])'
-            elseif npoint == 10
-                @test parent(parent(_x)) ≈ (x[:,1:5])'
-            end
+    p_data_local = parent(p_data)
+    if MPI.Comm_rank(MPI.COMM_WORLD) == 0
+        if length(n) == 2
+            @test p_data_local ≈ p_data_test[:,1:9,:]
         else
-            if npoint == 1
-                @test parent(parent(_x)) ≈ x'
-            elseif npoint == 5
-                @test parent(parent(_x)) ≈ (x[:,3:5])'
-            elseif npoint == 10
-                @test parent(parent(_x)) ≈ (x[:,6:10])'
-            end
+            @test p_data_local ≈ p_data_test[:,:,1:9,:]
         end
     end
-
-    @testset "Sparse time function, copy! and convert, n=$n, npoint=$npoint" for n in ( (11,10), (12,11,10) ), npoint in (1, 5, 10)
-        grid = Grid(shape=n, dtype=Float32)
-        nt = 100
-        stf = SparseTimeFunction(name="stf", npoint=npoint, nt=nt, grid=grid)
-
-        x = zeros(Float32, nt, npoint)
-        if MPI.Comm_rank(MPI.COMM_WORLD) == 0
-            x .= reshape(Float32[1:prod(nt*npoint);], nt, npoint)
+    if MPI.Comm_rank(MPI.COMM_WORLD) == 1
+        if length(n) == 2
+            @test p_data_local ≈ p_data_test[:,10:18,:]
+        else
+            @test p_data_local ≈ p_data_test[:,:,10:18,:]
         end
-        MPI.Barrier(MPI.COMM_WORLD)
-        _x = data(stf)
-        @test isa(data(stf), Transpose)
+    end
+    MPI.Barrier(MPI.COMM_WORLD)
+end
 
-        copy!(_x, x)
+@testset "DevitoMPITimeArray, copy!, data, halo, n=$n" for n in ( (11,10), (12,11,10))
+    grid = Grid(shape = n, dtype = Float32)
+    b = Devito.Function(name="b", grid=grid, space_order=2)
+    p = TimeFunction(name="p", grid=grid, time_order=2, space_order=2)
+    p_data = data_with_halo(p)
+
+    _n = length(n) == 2 ? (15,14,3) : (16,15,14,3)
+    p_data_test = zeros(Float32, _n)
+    if MPI.Comm_rank(MPI.COMM_WORLD) == 0
+        p_data_test .= reshape(Float32[1:prod(_n);], _n)
+    end
+    copy!(p_data, p_data_test)
+    p_data_test .= reshape(Float32[1:prod(_n);], _n)
+
+    p_data_local = parent(p_data)
+    if MPI.Comm_rank(MPI.COMM_WORLD) == 0
+        if length(n) == 2
+            @test p_data_local ≈ p_data_test[:,1:7,:]
+        else
+            @test p_data_local ≈ p_data_test[:,:,1:7,:]
+        end
+    end
+    if MPI.Comm_rank(MPI.COMM_WORLD) == 1
+        if length(n) == 2
+            @test p_data_local ≈ p_data_test[:,8:14,:]
+        else
+            @test p_data_local ≈ p_data_test[:,:,8:14,:]
+        end
+    end
+    MPI.Barrier(MPI.COMM_WORLD)
+end
+
+@testset "DevitoMPITimeArray, copy!, data, no halo, n=$n" for n in ( (11,10), (12,11,10))
+    grid = Grid(shape = n, dtype = Float32)
+    b = Devito.Function(name="b", grid=grid, space_order=2)
+    p = TimeFunction(name="p", grid=grid, time_order=2, space_order=2)
+    p_data = data(p)
+
+    _n = length(n) == 2 ? (11,10,3) : (12,11,10,3)
+    p_data_test = zeros(Float32, _n)
+    if MPI.Comm_rank(MPI.COMM_WORLD) == 0
+        p_data_test .= reshape(Float32[1:prod(_n);], _n)
+    end
+    copy!(p_data, p_data_test)
+    p_data_test .= reshape(Float32[1:prod(_n);], _n)
+
+    p_data_local = parent(p_data)
+    if MPI.Comm_rank(MPI.COMM_WORLD) == 0
+        if length(n) == 2
+            @test p_data_local ≈ p_data_test[:,1:5,:]
+        else
+            @test p_data_local ≈ p_data_test[:,:,1:5,:]
+        end
+    end
+    if MPI.Comm_rank(MPI.COMM_WORLD) == 1
+        if length(n) == 2
+            @test p_data_local ≈ p_data_test[:,6:10,:]
+        else
+            @test p_data_local ≈ p_data_test[:,:,6:10,:]
+        end
+    end
+    MPI.Barrier(MPI.COMM_WORLD)
+end
+
+@testset "convert data from rank 0 to DevitoMPITimeArray, then back, inhalo, n=$n" for n in ( (11,10), (12,11,10) )
+    grid = Grid(shape = n, dtype = Float32)
+    b = Devito.Function(name="b", grid=grid, space_order=2)
+    p = TimeFunction(name="p", grid=grid, time_order=2, space_order=2)
+    p_data = data_with_inhalo(p)
+
+    _n = length(n) == 2 ? (15,18,3) : (16,15,18,3)
+
+    p_data_test = zeros(Float32, _n)
+    if MPI.Comm_rank(MPI.COMM_WORLD) == 0
+        p_data_test .= reshape(Float32[1:prod(_n);], _n)
+    end
+    copy!(p_data, p_data_test)
+    p_data_test .= reshape(Float32[1:prod(_n);], _n)
+
+    _p_data_test = convert(Array, p_data)
+
+    if MPI.Comm_rank(MPI.COMM_WORLD) == 0
+        @test p_data_test ≈ _p_data_test
+    end
+end
+
+@testset "convert data from rank 0 to DevitoMPITimeArray, then back, halo, n=$n" for n in ( (11,10), (12,11,10) )
+    grid = Grid(shape = n, dtype = Float32)
+    b = Devito.Function(name="b", grid=grid, space_order=2)
+    p = TimeFunction(name="p", grid=grid, time_order=2, space_order=2)
+    p_data = data_with_halo(p)
+
+    _n = length(n) == 2 ? (15,14,3) : (16,15,14,3)
+
+    p_data_test = zeros(Float32, _n)
+    if MPI.Comm_rank(MPI.COMM_WORLD) == 0
+        p_data_test .= reshape(Float32[1:prod(_n);], _n)
+    end
+    copy!(p_data, p_data_test)
+    p_data_test .= reshape(Float32[1:prod(_n);], _n)
+
+    _p_data_test = convert(Array, p_data)
+
+    if MPI.Comm_rank(MPI.COMM_WORLD) == 0
+        @test p_data_test ≈ _p_data_test
+    end
+end
+
+@testset "convert data from rank 0 to DevitoMPITimeArray, then back, no halo, n=$n" for n in ( (11,10), (12,11,10) )
+    grid = Grid(shape = n, dtype = Float32)
+    b = Devito.Function(name="b", grid=grid, space_order=2)
+    p = TimeFunction(name="p", grid=grid, time_order=2, space_order=2)
+    p_data = data(p)
+
+    _n = length(n) == 2 ? (11,10,3) : (12,11,10,3)
+
+    p_data_test = zeros(Float32, _n)
+    if MPI.Comm_rank(MPI.COMM_WORLD) == 0
+        p_data_test .= reshape(Float32[1:prod(_n);], _n)
+    end
+    copy!(p_data, p_data_test)
+    p_data_test .= reshape(Float32[1:prod(_n);], _n)
+
+    _p_data_test = convert(Array, p_data)
+
+    if MPI.Comm_rank(MPI.COMM_WORLD) == 0
+        @test p_data_test ≈ _p_data_test
+    end
+end
+
+@testset "Sparse time function coordinates, n=$n, npoint=$npoint" for n in ( (11,10), (12,11,10) ), npoint in (1, 5, 10)
+    grid = Grid(shape=n, dtype=Float32)
+    stf = SparseTimeFunction(name="stf", npoint=npoint, nt=100, grid=grid)
+    stf_coords = coordinates(stf)
+    @test isa(stf_coords, Devito.DevitoMPIArray)
+    @test size(stf_coords) == (length(n),npoint)
+    x = rand(Float32,length(n),npoint)
+
+    copy!(stf_coords, x)
+
+    _stf_coords = convert(Array,coordinates(stf))
+
+    if MPI.Comm_rank(MPI.COMM_WORLD) == 0
+        @test _stf_coords ≈ x
+    end
+end
+
+@testset "Sparse time function, copy!, n=$n, npoint=$npoint" for n in ( (11,10), (12,11,10) ), npoint in (1, 5, 10)
+    grid = Grid(shape=n, dtype=Float32)
+    nt = 100
+    stf = SparseTimeFunction(name="stf", npoint=npoint, nt=nt, grid=grid)
+
+    x = Matrix{Float32}(undef,0,0)
+    if MPI.Comm_rank(MPI.COMM_WORLD) == 0
+        x = reshape(Float32[1:prod(nt*npoint);], nt, npoint)
+    end
+    
+    _x = data(stf)
+    copy!(_x, x)
+    x = reshape(Float32[1:prod(nt*npoint);], nt, npoint)
+
+    if MPI.Comm_rank(MPI.COMM_WORLD) == 0
+        if npoint == 1
+            @test isempty(parent(parent(_x)))
+        elseif npoint == 5
+            @test parent(parent(_x)) ≈ (x[:,1:2])'
+        elseif npoint == 10
+            @test parent(parent(_x)) ≈ (x[:,1:5])'
+        end
+    else
+        if npoint == 1
+            @test parent(parent(_x)) ≈ x'
+        elseif npoint == 5
+            @test parent(parent(_x)) ≈ (x[:,3:5])'
+        elseif npoint == 10
+            @test parent(parent(_x)) ≈ (x[:,6:10])'
+        end
+    end
+end
+
+@testset "Sparse time function, copy! and convert, n=$n, npoint=$npoint" for n in ( (11,10), (12,11,10) ), npoint in (1, 5, 10)
+    grid = Grid(shape=n, dtype=Float32)
+    nt = 100
+    stf = SparseTimeFunction(name="stf", npoint=npoint, nt=nt, grid=grid)
+
+    x = zeros(Float32, nt, npoint)
+    if MPI.Comm_rank(MPI.COMM_WORLD) == 0
         x .= reshape(Float32[1:prod(nt*npoint);], nt, npoint)
-
-        __x = convert(Array, _x)
-        if MPI.Comm_rank(MPI.COMM_WORLD) == 0
-            @test __x ≈ x
-        end
     end
+    MPI.Barrier(MPI.COMM_WORLD)
+    _x = data(stf)
+    @test isa(data(stf), Transpose)
 
-    @testset "DevitoMPISparseArray copy! axes check, n=$n" for n in ( (11,10), (12,11,10) )
-        grid = Grid(shape=n, dtype=Float32)
-        stf = SparseTimeFunction(name="stf", npoint=10, nt=100, grid=grid)
-        stf_data = data(stf)
-        @test size(stf_data) == (100,10)
-        x = rand(10,100)
+    copy!(_x, x)
+    x .= reshape(Float32[1:prod(nt*npoint);], nt, npoint)
+
+    __x = convert(Array, _x)
+    if MPI.Comm_rank(MPI.COMM_WORLD) == 0
+        @test __x ≈ x
+    end
+end
+
+@testset "DevitoMPISparseArray copy! axes check, n=$n" for n in ( (11,10), (12,11,10) )
+    grid = Grid(shape=n, dtype=Float32)
+    stf = SparseTimeFunction(name="stf", npoint=10, nt=100, grid=grid)
+    stf_data = data(stf)
+    @test size(stf_data) == (100,10)
+    x = rand(10,100)
+    if MPI.Comm_rank(MPI.COMM_WORLD) == 0
         @test_throws ArgumentError copy!(stf_data, x)
     end
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,3 +1,5 @@
-for testscript in ("mpitests.jl", "serialtests.jl", "gencodetests.jl")
+for testscript in ("serialtests.jl", "gencodetests.jl")
     include(testscript)
 end
+
+run(`mpirun -n 2 julia mpitests.jl`)


### PR DESCRIPTION
Changes mpi unit tests to execute using `mpirun`
Modifies the `copy!` method for devitompiarrays so the dimension check is only performed on the main rank, allowing empty arrays to be used on non-main ranks provided they are of the right dtype and dimensionality.
