### PR TITLE
Nvidia gpu 

### DIFF
--- a/deps/build.jl
+++ b/deps/build.jl
@@ -1,19 +1,20 @@
-using Conda
+# using Conda
 
-try
-    Conda.add("pip")
-    pip = joinpath(Conda.BINDIR, "pip")
-    run(`$pip install cython`) 
-    run(`$pip install versioneer`) 
-    run(`$pip install git+https://github.com/devitocodes/devito.git`)
-    run(`$pip install mpi4py`)
-    run(`$pip install ipyparallel`)
-catch e
-    if get(ENV, "JULIA_REGISTRYCI_AUTOMERGE", "false") == "true"
-        @warn unable to build
-    else
-        throw(e)
-    end
-end
+# try
+#     Conda.add("pip")
+#     pip = joinpath(Conda.BINDIR, "pip")
+#     run(`$pip install cython`) 
+#     run(`$pip install versioneer`) 
+#     run(`$pip install git+https://github.com/devitocodes/devito.git`)
+#     run(`$pip install mpi4py`)
+#     run(`$pip install ipyparallel`)
+# catch e
+#     if get(ENV, "JULIA_REGISTRYCI_AUTOMERGE", "false") == "true"
+#         @warn unable to build
+#     else
+#         throw(e)
+#     end
+# end
+
 #run(`$pip install devito`)
 #run(`$pip install devito[extras]`)


### PR DESCRIPTION
I have added modifications to the environment variables dict `ENV` and the devito `configuration` dictionary to target Nvidia GPU via openacc offloading.

complication: so far it looks like the `nvc` compiler is not found when you modify `PATH` with julia `ENV` in the `configure_nvidia_hpcsdk` function: the `PATH` needs to be good when you call julia. 

example:

```
julia> using Devito

julia> Devito.configure_nvidia_hpcsdk("22.3")
PyCall.PyDict{PyCall.PyAny, PyCall.PyAny, true} with 15 entries:
  "platform"        => PyObject TargetPlatform[nvidiaX]
  "compiler"        => PyObject JITCompiler[NvidiaCompiler]
  "language"        => "openacc"
  "mpi"             => false
  "first-touch"     => false
  "ignore-unknowns" => false
  "log-level"       => "INFO"
  "jit-backdoor"    => false
  "safe-math"       => false
  "autopadding"     => false
  "autotuning"      => (false, "preemptive")
  "develop-mode"    => true
  "opt"             => "advanced"
  "opt-options"     => Dict{Any, Any}()
  "profiling"       => "basic"
```