### PR TITLE
Fix gather of MPI time function arrays

### DIFF
--- a/src/Devito.jl
+++ b/src/Devito.jl
@@ -184,27 +184,64 @@ copyto_permutedims_forward(N) = ntuple(i->i == 1 ? N : i - 1, N)
 copyto_permutedims_forward(n::NTuple{N,Int}) where {N} = ntuple(i->i == 1 ? n[N] : n[i-1], N)
 copyto_permutedims_reverse(N) = ntuple(i->i == N ? 1 : i + 1, N)
 
+#=
+These are specialized version for 3 and 4 dimensions.  They seems to run faster than the N dimension
+version.  I guess this is becuase it is non-allocating, where-as the N dimension version does
+allocate memory.
+=#
+function convert_resort_timearray!(_y::Array{T,3}, y::Vector{T}, topology, decomposition) where {T}
+    i = 1
+    for idx in CartesianIndices(topology)
+        for i3 in 1:size(_y,3), i2 in decomposition[2][idx.I[2]], i1 in decomposition[1][idx.I[1]]
+            _y[i1,i2,i3] = y[i]
+            i += 1
+        end
+    end
+    _y
+end
+
+function convert_resort_timearray!(_y::Array{T,4}, y::Vector{T}, topology, decomposition) where {T}
+    i = 1
+    for idx in CartesianIndices(topology)
+        for i4 in 1:size(_y,4), i3 in decomposition[3][idx.I[3]], i2 in decomposition[2][idx.I[2]], i1 in decomposition[1][idx.I[1]]
+            _y[i1,i2,i3,i4] = y[i]
+            i += 1
+        end
+    end
+    _y
+end
+
+function convert_resort_timearray!(_y::Array{T,N}, y::Vector{T}, topology, decomposition) where {T,N}
+    i = 1
+    for block_idx in CartesianIndices(topology)
+        idxs = CartesianIndices(ntuple(idim->decomposition[idim] === nothing ? size(_y, idim) : length(decomposition[idim][block_idx.I[idim]]), N))
+        for _idx in idxs
+            idx = CartesianIndex(ntuple(idim->decomposition[idim] === nothing ? _idx.I[idim] : decomposition[idim][block_idx.I[idim]][_idx.I[idim]], N))
+            _y[idx] = y[i]
+            i += 1
+        end
+    end
+    _y
+end
+
 function Base.convert(::Type{Array}, x::DevitoMPITimeArray{T,N}) where {T,N}
     local y
     if MPI.Comm_rank(MPI.COMM_WORLD) == 0
-        y = zeros(T, copyto_permutedims_forward(size(x)))
+        y = zeros(T, length(x))
         y_vbuffer = VBuffer(y, counts(x))
     else
-        y = Array{T,N}(undef, ntuple(_->0, N))
+        y = Vector{T}(undef, 0)
         y_vbuffer = VBuffer(nothing)
     end
+    MPI.Gatherv!(convert(Array, parent(x)), y_vbuffer, 0, MPI.COMM_WORLD)
 
-    _x = zeros(T, copyto_permutedims_forward(size(parent(x))))
-    copyto!(_x, permutedims(parent(x), copyto_permutedims_forward(N)))
-    MPI.Gatherv!(_x, y_vbuffer, 0, MPI.COMM_WORLD)
-
-    local __x
     if MPI.Comm_rank(MPI.COMM_WORLD) == 0
-        __x = permutedims(y, copyto_permutedims_reverse(N))
+        _y = convert_resort_timearray!(Array{T,N}(undef, size(x)), y, x.topology, x.decomposition)
     else
-        __x = Array{T,N}(undef, ntuple(_->0, N))
+        _y = zeros(T, ntuple(_->0, N))
     end
-    __x
+
+    _y
 end
 
 function Base.copy!(dst::DevitoMPIAbstractArray, src::AbstractArray)

--- a/test/mpitests_2ranks.jl
+++ b/test/mpitests_2ranks.jl
@@ -394,6 +394,107 @@ end
     end
 end
 
+@testset "DevitoMPITimeArray coordinates check, 2D" begin
+    ny,nx = 4,6
+
+    grd = Grid(shape=(ny,nx), extent=(ny-1,nx-1), dtype=Float32)
+    time_order = 1
+    fx = TimeFunction(name="fx", grid=grd, time_order=time_order, save=time_order+1)
+    fy = TimeFunction(name="fy", grid=grd, time_order=time_order, save=time_order+1)
+    sx = SparseTimeFunction(name="sx", grid=grd, npoint=ny*nx, nt=time_order+1)
+    sy = SparseTimeFunction(name="sy", grid=grd, npoint=ny*nx, nt=time_order+1)
+
+    cx = [ix-1 for iy = 1:ny, ix=1:nx][:]
+    cy = [iy-1 for iy = 1:ny, ix=1:nx][:]
+
+    coords = zeros(Float32, 2, ny*nx)
+    coords[1,:] .= cx
+    coords[2,:] .= cy
+    copy!(coordinates(sx), coords)
+    copy!(coordinates(sy), coords)
+
+    datx = reshape(Float32[ix for iy = 1:ny, ix=1:nx, it = 1:time_order+1][:], nx*ny, time_order+1)
+    daty = reshape(Float32[iy for iy = 1:ny, ix=1:nx, it = 1:time_order+1][:], nx*ny, time_order+1)
+
+    copy!(data(sx), datx)
+    copy!(data(sy), daty)
+
+    eqx = inject(sx, field=forward(fx), expr=sx)
+    eqy = inject(sy, field=forward(fy), expr=sy)
+    op = Operator([eqx, eqy], name="CoordOp")
+    apply(op)
+
+    x = convert(Array, data(fx))
+    y = convert(Array, data(fy))
+
+    if MPI.Comm_rank(MPI.COMM_WORLD) == 0
+        if VERSION >= v"1.7"
+            @test x ≈ [0.0 0.0 0.0 0.0 0.0 0.0; 0.0 0.0 0.0 0.0 0.0 0.0; 0.0 0.0 0.0 0.0 0.0 0.0; 0.0 0.0 0.0 0.0 0.0 0.0;;; 1.0 2.0 3.0 4.0 5.0 6.0; 1.0 2.0 3.0 4.0 5.0 6.0; 1.0 2.0 3.0 4.0 5.0 6.0; 1.0 2.0 3.0 4.0 5.0 6.0]
+            @test y ≈ [0.0 0.0 0.0 0.0 0.0 0.0; 0.0 0.0 0.0 0.0 0.0 0.0; 0.0 0.0 0.0 0.0 0.0 0.0; 0.0 0.0 0.0 0.0 0.0 0.0;;; 1.0 1.0 1.0 1.0 1.0 1.0; 2.0 2.0 2.0 2.0 2.0 2.0; 3.0 3.0 3.0 3.0 3.0 3.0; 4.0 4.0 4.0 4.0 4.0 4.0]
+        else
+            _x = zeros(Float32, ny, nx, 2)
+            _x[:,:,1] .= [0.0 0.0 0.0 0.0 0.0 0.0; 0.0 0.0 0.0 0.0 0.0 0.0; 0.0 0.0 0.0 0.0 0.0 0.0; 0.0 0.0 0.0 0.0 0.0 0.0]
+            _x[:,:,2] .= [1.0 2.0 3.0 4.0 5.0 6.0; 1.0 2.0 3.0 4.0 5.0 6.0; 1.0 2.0 3.0 4.0 5.0 6.0; 1.0 2.0 3.0 4.0 5.0 6.0]
+            @test x ≈ _x
+            _y = zeros(Float32, ny, nx, 2)
+            _y[:,:,1] .= [0.0 0.0 0.0 0.0 0.0 0.0; 0.0 0.0 0.0 0.0 0.0 0.0; 0.0 0.0 0.0 0.0 0.0 0.0; 0.0 0.0 0.0 0.0 0.0 0.0]
+            _y[:,:,2] .= [1.0 1.0 1.0 1.0 1.0 1.0; 2.0 2.0 2.0 2.0 2.0 2.0; 3.0 3.0 3.0 3.0 3.0 3.0; 4.0 4.0 4.0 4.0 4.0 4.0]
+            @test y ≈ _y
+        end
+    end
+end
+
+@testset "DevitoMPITimeArray coordinates check, 3D" begin
+    nz,ny,nx = 4,5,6
+
+    grd = Grid(shape=(nz,ny,nx), extent=(nz-1,ny-1,nx-1), dtype=Float32)
+    time_order = 1
+    fx = TimeFunction(name="fx", grid=grd, time_order=time_order, save=time_order+1)
+    fy = TimeFunction(name="fy", grid=grd, time_order=time_order, save=time_order+1)
+    fz = TimeFunction(name="fz", grid=grd, time_order=time_order, save=time_order+1)
+    sx = SparseTimeFunction(name="sx", grid=grd, npoint=nz*ny*nx, nt=time_order+1)
+    sy = SparseTimeFunction(name="sy", grid=grd, npoint=nz*ny*nx, nt=time_order+1)
+    sz = SparseTimeFunction(name="sz", grid=grd, npoint=nz*ny*nx, nt=time_order+1)
+
+    cx = [ix-1 for iz = 1:nz, iy = 1:ny, ix=1:nx][:]
+    cy = [iy-1 for iz = 1:nz, iy = 1:ny, ix=1:nx][:]
+    cz = [iz-1 for iz = 1:nz, iy = 1:ny, ix=1:nx][:]
+
+    coords = zeros(Float32, 3, nz*ny*nx)
+    coords[1,:] .= cx
+    coords[2,:] .= cy
+    coords[3,:] .= cz
+    copy!(coordinates(sx), coords)
+    copy!(coordinates(sy), coords)
+    copy!(coordinates(sz), coords)
+
+    datx = reshape(Float32[ix for iz = 1:nz, iy = 1:ny, ix=1:nx, it = 1:time_order+1][:], nx*ny*nz, time_order+1)
+    daty = reshape(Float32[iy for iz = 1:nz, iy = 1:ny, ix=1:nx, it = 1:time_order+1][:], nx*ny*nz, time_order+1)
+    datz = reshape(Float32[iz for iz = 1:nz, iy = 1:ny, ix=1:nx, it = 1:time_order+1][:], nx*ny*nz, time_order+1)
+
+    copy!(data(sx), datx)
+    copy!(data(sy), daty)
+    copy!(data(sz), datz)
+
+    eqx = inject(sx, field=forward(fx), expr=sx)
+    eqy = inject(sy, field=forward(fy), expr=sy)
+    eqz = inject(sz, field=forward(fz), expr=sz)
+    op = Operator([eqx, eqy, eqz], name="CoordOp")
+    apply(op)
+
+    x = convert(Array, data(fx))
+    y = convert(Array, data(fy))
+    z = convert(Array, data(fz))
+
+    if MPI.Comm_rank(MPI.COMM_WORLD) == 0
+        if VERSION >= v"1.7"
+            @test x ≈ [0.0 0.0 0.0 0.0 0.0; 0.0 0.0 0.0 0.0 0.0; 0.0 0.0 0.0 0.0 0.0; 0.0 0.0 0.0 0.0 0.0;;; 0.0 0.0 0.0 0.0 0.0; 0.0 0.0 0.0 0.0 0.0; 0.0 0.0 0.0 0.0 0.0; 0.0 0.0 0.0 0.0 0.0;;; 0.0 0.0 0.0 0.0 0.0; 0.0 0.0 0.0 0.0 0.0; 0.0 0.0 0.0 0.0 0.0; 0.0 0.0 0.0 0.0 0.0;;; 0.0 0.0 0.0 0.0 0.0; 0.0 0.0 0.0 0.0 0.0; 0.0 0.0 0.0 0.0 0.0; 0.0 0.0 0.0 0.0 0.0;;; 0.0 0.0 0.0 0.0 0.0; 0.0 0.0 0.0 0.0 0.0; 0.0 0.0 0.0 0.0 0.0; 0.0 0.0 0.0 0.0 0.0;;; 0.0 0.0 0.0 0.0 0.0; 0.0 0.0 0.0 0.0 0.0; 0.0 0.0 0.0 0.0 0.0; 0.0 0.0 0.0 0.0 0.0;;;; 1.0 1.0 1.0 1.0 1.0; 1.0 1.0 1.0 1.0 1.0; 1.0 1.0 1.0 1.0 1.0; 1.0 1.0 1.0 1.0 1.0;;; 2.0 2.0 2.0 2.0 2.0; 2.0 2.0 2.0 2.0 2.0; 2.0 2.0 2.0 2.0 2.0; 2.0 2.0 2.0 2.0 2.0;;; 3.0 3.0 3.0 3.0 3.0; 3.0 3.0 3.0 3.0 3.0; 3.0 3.0 3.0 3.0 3.0; 3.0 3.0 3.0 3.0 3.0;;; 4.0 4.0 4.0 4.0 4.0; 4.0 4.0 4.0 4.0 4.0; 4.0 4.0 4.0 4.0 4.0; 4.0 4.0 4.0 4.0 4.0;;; 5.0 5.0 5.0 5.0 5.0; 5.0 5.0 5.0 5.0 5.0; 5.0 5.0 5.0 5.0 5.0; 5.0 5.0 5.0 5.0 5.0;;; 6.0 6.0 6.0 6.0 6.0; 6.0 6.0 6.0 6.0 6.0; 6.0 6.0 6.0 6.0 6.0; 6.0 6.0 6.0 6.0 6.0]
+            @test y ≈ [0.0 0.0 0.0 0.0 0.0; 0.0 0.0 0.0 0.0 0.0; 0.0 0.0 0.0 0.0 0.0; 0.0 0.0 0.0 0.0 0.0;;; 0.0 0.0 0.0 0.0 0.0; 0.0 0.0 0.0 0.0 0.0; 0.0 0.0 0.0 0.0 0.0; 0.0 0.0 0.0 0.0 0.0;;; 0.0 0.0 0.0 0.0 0.0; 0.0 0.0 0.0 0.0 0.0; 0.0 0.0 0.0 0.0 0.0; 0.0 0.0 0.0 0.0 0.0;;; 0.0 0.0 0.0 0.0 0.0; 0.0 0.0 0.0 0.0 0.0; 0.0 0.0 0.0 0.0 0.0; 0.0 0.0 0.0 0.0 0.0;;; 0.0 0.0 0.0 0.0 0.0; 0.0 0.0 0.0 0.0 0.0; 0.0 0.0 0.0 0.0 0.0; 0.0 0.0 0.0 0.0 0.0;;; 0.0 0.0 0.0 0.0 0.0; 0.0 0.0 0.0 0.0 0.0; 0.0 0.0 0.0 0.0 0.0; 0.0 0.0 0.0 0.0 0.0;;;; 1.0 2.0 3.0 4.0 5.0; 1.0 2.0 3.0 4.0 5.0; 1.0 2.0 3.0 4.0 5.0; 1.0 2.0 3.0 4.0 5.0;;; 1.0 2.0 3.0 4.0 5.0; 1.0 2.0 3.0 4.0 5.0; 1.0 2.0 3.0 4.0 5.0; 1.0 2.0 3.0 4.0 5.0;;; 1.0 2.0 3.0 4.0 5.0; 1.0 2.0 3.0 4.0 5.0; 1.0 2.0 3.0 4.0 5.0; 1.0 2.0 3.0 4.0 5.0;;; 1.0 2.0 3.0 4.0 5.0; 1.0 2.0 3.0 4.0 5.0; 1.0 2.0 3.0 4.0 5.0; 1.0 2.0 3.0 4.0 5.0;;; 1.0 2.0 3.0 4.0 5.0; 1.0 2.0 3.0 4.0 5.0; 1.0 2.0 3.0 4.0 5.0; 1.0 2.0 3.0 4.0 5.0;;; 1.0 2.0 3.0 4.0 5.0; 1.0 2.0 3.0 4.0 5.0; 1.0 2.0 3.0 4.0 5.0; 1.0 2.0 3.0 4.0 5.0]
+            @test z ≈ [0.0 0.0 0.0 0.0 0.0; 0.0 0.0 0.0 0.0 0.0; 0.0 0.0 0.0 0.0 0.0; 0.0 0.0 0.0 0.0 0.0;;; 0.0 0.0 0.0 0.0 0.0; 0.0 0.0 0.0 0.0 0.0; 0.0 0.0 0.0 0.0 0.0; 0.0 0.0 0.0 0.0 0.0;;; 0.0 0.0 0.0 0.0 0.0; 0.0 0.0 0.0 0.0 0.0; 0.0 0.0 0.0 0.0 0.0; 0.0 0.0 0.0 0.0 0.0;;; 0.0 0.0 0.0 0.0 0.0; 0.0 0.0 0.0 0.0 0.0; 0.0 0.0 0.0 0.0 0.0; 0.0 0.0 0.0 0.0 0.0;;; 0.0 0.0 0.0 0.0 0.0; 0.0 0.0 0.0 0.0 0.0; 0.0 0.0 0.0 0.0 0.0; 0.0 0.0 0.0 0.0 0.0;;; 0.0 0.0 0.0 0.0 0.0; 0.0 0.0 0.0 0.0 0.0; 0.0 0.0 0.0 0.0 0.0; 0.0 0.0 0.0 0.0 0.0;;;; 1.0 1.0 1.0 1.0 1.0; 2.0 2.0 2.0 2.0 2.0; 3.0 3.0 3.0 3.0 3.0; 4.0 4.0 4.0 4.0 4.0;;; 1.0 1.0 1.0 1.0 1.0; 2.0 2.0 2.0 2.0 2.0; 3.0 3.0 3.0 3.0 3.0; 4.0 4.0 4.0 4.0 4.0;;; 1.0 1.0 1.0 1.0 1.0; 2.0 2.0 2.0 2.0 2.0; 3.0 3.0 3.0 3.0 3.0; 4.0 4.0 4.0 4.0 4.0;;; 1.0 1.0 1.0 1.0 1.0; 2.0 2.0 2.0 2.0 2.0; 3.0 3.0 3.0 3.0 3.0; 4.0 4.0 4.0 4.0 4.0;;; 1.0 1.0 1.0 1.0 1.0; 2.0 2.0 2.0 2.0 2.0; 3.0 3.0 3.0 3.0 3.0; 4.0 4.0 4.0 4.0 4.0;;; 1.0 1.0 1.0 1.0 1.0; 2.0 2.0 2.0 2.0 2.0; 3.0 3.0 3.0 3.0 3.0; 4.0 4.0 4.0 4.0 4.0]
+        end
+    end
+end
+
 @testset "Sparse time function coordinates, n=$n, npoint=$npoint" for n in ( (11,10), (12,11,10) ), npoint in (1, 5, 10)
     grid = Grid(shape=n, dtype=Float32)
     stf = SparseTimeFunction(name="stf", npoint=npoint, nt=100, grid=grid)

--- a/test/mpitests_4ranks.jl
+++ b/test/mpitests_4ranks.jl
@@ -1,0 +1,107 @@
+using Devito, LinearAlgebra, MPI, Random, Strided, Test
+
+MPI.Init()
+configuration!("log-level", "DEBUG")
+configuration!("language", "openmp")
+configuration!("mpi", true)
+
+@testset "DevitoMPITimeArray coordinates check" begin
+    ny,nx = 4,6
+
+    grd = Grid(shape=(ny,nx), extent=(ny-1,nx-1), dtype=Float32)
+    time_order = 1
+    fx = TimeFunction(name="fx", grid=grd, time_order=time_order, save=time_order+1)
+    fy = TimeFunction(name="fy", grid=grd, time_order=time_order, save=time_order+1)
+    sx = SparseTimeFunction(name="sx", grid=grd, npoint=ny*nx, nt=time_order+1)
+    sy = SparseTimeFunction(name="sy", grid=grd, npoint=ny*nx, nt=time_order+1)
+
+    cx = [ix-1 for iy = 1:ny, ix=1:nx][:]
+    cy = [iy-1 for iy = 1:ny, ix=1:nx][:]
+
+    coords = zeros(Float32, 2, ny*nx)
+    coords[1,:] .= cx
+    coords[2,:] .= cy
+    copy!(coordinates(sx), coords)
+    copy!(coordinates(sy), coords)
+
+    datx = reshape(Float32[ix for iy = 1:ny, ix=1:nx, it = 1:time_order+1][:], nx*ny, time_order+1)
+    daty = reshape(Float32[iy for iy = 1:ny, ix=1:nx, it = 1:time_order+1][:], nx*ny, time_order+1)
+
+    copy!(data(sx), datx)
+    copy!(data(sy), daty)
+
+    eqx = inject(sx, field=forward(fx), expr=sx)
+    eqy = inject(sy, field=forward(fy), expr=sy)
+    op = Operator([eqx, eqy], name="CoordOp")
+    apply(op)
+
+    x = convert(Array, data(fx))
+    y = convert(Array, data(fy))
+
+    if MPI.Comm_rank(MPI.COMM_WORLD) == 0
+        if VERSION >= v"1.7"
+            @test x ≈ [0.0 0.0 0.0 0.0 0.0 0.0; 0.0 0.0 0.0 0.0 0.0 0.0; 0.0 0.0 0.0 0.0 0.0 0.0; 0.0 0.0 0.0 0.0 0.0 0.0;;; 1.0 2.0 3.0 4.0 5.0 6.0; 1.0 2.0 3.0 4.0 5.0 6.0; 1.0 2.0 3.0 4.0 5.0 6.0; 1.0 2.0 3.0 4.0 5.0 6.0]
+            @test y ≈ [0.0 0.0 0.0 0.0 0.0 0.0; 0.0 0.0 0.0 0.0 0.0 0.0; 0.0 0.0 0.0 0.0 0.0 0.0; 0.0 0.0 0.0 0.0 0.0 0.0;;; 1.0 1.0 1.0 1.0 1.0 1.0; 2.0 2.0 2.0 2.0 2.0 2.0; 3.0 3.0 3.0 3.0 3.0 3.0; 4.0 4.0 4.0 4.0 4.0 4.0]
+        else
+            _x = zeros(Float32, ny, nx, 2)
+            _x[:,:,1] .= [0.0 0.0 0.0 0.0 0.0 0.0; 0.0 0.0 0.0 0.0 0.0 0.0; 0.0 0.0 0.0 0.0 0.0 0.0; 0.0 0.0 0.0 0.0 0.0 0.0]
+            _x[:,:,2] .= [1.0 2.0 3.0 4.0 5.0 6.0; 1.0 2.0 3.0 4.0 5.0 6.0; 1.0 2.0 3.0 4.0 5.0 6.0; 1.0 2.0 3.0 4.0 5.0 6.0]
+            @test x ≈ _x
+            _y = zeros(Float32, ny, nx, 2)
+            _y[:,:,1] .= [0.0 0.0 0.0 0.0 0.0 0.0; 0.0 0.0 0.0 0.0 0.0 0.0; 0.0 0.0 0.0 0.0 0.0 0.0; 0.0 0.0 0.0 0.0 0.0 0.0]
+            _y[:,:,2] .= [1.0 1.0 1.0 1.0 1.0 1.0; 2.0 2.0 2.0 2.0 2.0 2.0; 3.0 3.0 3.0 3.0 3.0 3.0; 4.0 4.0 4.0 4.0 4.0 4.0]
+            @test y ≈ _y
+        end
+    end
+end
+
+@testset "DevitoMPITimeArray coordinates check, 3D" begin
+    nz,ny,nx = 4,5,6
+
+    grd = Grid(shape=(nz,ny,nx), extent=(nz-1,ny-1,nx-1), dtype=Float32)
+    time_order = 1
+    fx = TimeFunction(name="fx", grid=grd, time_order=time_order, save=time_order+1)
+    fy = TimeFunction(name="fy", grid=grd, time_order=time_order, save=time_order+1)
+    fz = TimeFunction(name="fz", grid=grd, time_order=time_order, save=time_order+1)
+    sx = SparseTimeFunction(name="sx", grid=grd, npoint=nz*ny*nx, nt=time_order+1)
+    sy = SparseTimeFunction(name="sy", grid=grd, npoint=nz*ny*nx, nt=time_order+1)
+    sz = SparseTimeFunction(name="sz", grid=grd, npoint=nz*ny*nx, nt=time_order+1)
+
+    cx = [ix-1 for iz = 1:nz, iy = 1:ny, ix=1:nx][:]
+    cy = [iy-1 for iz = 1:nz, iy = 1:ny, ix=1:nx][:]
+    cz = [iz-1 for iz = 1:nz, iy = 1:ny, ix=1:nx][:]
+
+    coords = zeros(Float32, 3, nz*ny*nx)
+    coords[1,:] .= cx
+    coords[2,:] .= cy
+    coords[3,:] .= cz
+    copy!(coordinates(sx), coords)
+    copy!(coordinates(sy), coords)
+    copy!(coordinates(sz), coords)
+
+    datx = reshape(Float32[ix for iz = 1:nz, iy = 1:ny, ix=1:nx, it = 1:time_order+1][:], nx*ny*nz, time_order+1)
+    daty = reshape(Float32[iy for iz = 1:nz, iy = 1:ny, ix=1:nx, it = 1:time_order+1][:], nx*ny*nz, time_order+1)
+    datz = reshape(Float32[iz for iz = 1:nz, iy = 1:ny, ix=1:nx, it = 1:time_order+1][:], nx*ny*nz, time_order+1)
+
+    copy!(data(sx), datx)
+    copy!(data(sy), daty)
+    copy!(data(sz), datz)
+
+    eqx = inject(sx, field=forward(fx), expr=sx)
+    eqy = inject(sy, field=forward(fy), expr=sy)
+    eqz = inject(sz, field=forward(fz), expr=sz)
+    op = Operator([eqx, eqy, eqz], name="CoordOp")
+    apply(op)
+
+    x = convert(Array, data(fx))
+    y = convert(Array, data(fy))
+    z = convert(Array, data(fz))
+
+    if MPI.Comm_rank(MPI.COMM_WORLD) == 0
+        if VERSION >= v"1.7"
+            @test x ≈ [0.0 0.0 0.0 0.0 0.0; 0.0 0.0 0.0 0.0 0.0; 0.0 0.0 0.0 0.0 0.0; 0.0 0.0 0.0 0.0 0.0;;; 0.0 0.0 0.0 0.0 0.0; 0.0 0.0 0.0 0.0 0.0; 0.0 0.0 0.0 0.0 0.0; 0.0 0.0 0.0 0.0 0.0;;; 0.0 0.0 0.0 0.0 0.0; 0.0 0.0 0.0 0.0 0.0; 0.0 0.0 0.0 0.0 0.0; 0.0 0.0 0.0 0.0 0.0;;; 0.0 0.0 0.0 0.0 0.0; 0.0 0.0 0.0 0.0 0.0; 0.0 0.0 0.0 0.0 0.0; 0.0 0.0 0.0 0.0 0.0;;; 0.0 0.0 0.0 0.0 0.0; 0.0 0.0 0.0 0.0 0.0; 0.0 0.0 0.0 0.0 0.0; 0.0 0.0 0.0 0.0 0.0;;; 0.0 0.0 0.0 0.0 0.0; 0.0 0.0 0.0 0.0 0.0; 0.0 0.0 0.0 0.0 0.0; 0.0 0.0 0.0 0.0 0.0;;;; 1.0 1.0 1.0 1.0 1.0; 1.0 1.0 1.0 1.0 1.0; 1.0 1.0 1.0 1.0 1.0; 1.0 1.0 1.0 1.0 1.0;;; 2.0 2.0 2.0 2.0 2.0; 2.0 2.0 2.0 2.0 2.0; 2.0 2.0 2.0 2.0 2.0; 2.0 2.0 2.0 2.0 2.0;;; 3.0 3.0 3.0 3.0 3.0; 3.0 3.0 3.0 3.0 3.0; 3.0 3.0 3.0 3.0 3.0; 3.0 3.0 3.0 3.0 3.0;;; 4.0 4.0 4.0 4.0 4.0; 4.0 4.0 4.0 4.0 4.0; 4.0 4.0 4.0 4.0 4.0; 4.0 4.0 4.0 4.0 4.0;;; 5.0 5.0 5.0 5.0 5.0; 5.0 5.0 5.0 5.0 5.0; 5.0 5.0 5.0 5.0 5.0; 5.0 5.0 5.0 5.0 5.0;;; 6.0 6.0 6.0 6.0 6.0; 6.0 6.0 6.0 6.0 6.0; 6.0 6.0 6.0 6.0 6.0; 6.0 6.0 6.0 6.0 6.0]
+            @test y ≈ [0.0 0.0 0.0 0.0 0.0; 0.0 0.0 0.0 0.0 0.0; 0.0 0.0 0.0 0.0 0.0; 0.0 0.0 0.0 0.0 0.0;;; 0.0 0.0 0.0 0.0 0.0; 0.0 0.0 0.0 0.0 0.0; 0.0 0.0 0.0 0.0 0.0; 0.0 0.0 0.0 0.0 0.0;;; 0.0 0.0 0.0 0.0 0.0; 0.0 0.0 0.0 0.0 0.0; 0.0 0.0 0.0 0.0 0.0; 0.0 0.0 0.0 0.0 0.0;;; 0.0 0.0 0.0 0.0 0.0; 0.0 0.0 0.0 0.0 0.0; 0.0 0.0 0.0 0.0 0.0; 0.0 0.0 0.0 0.0 0.0;;; 0.0 0.0 0.0 0.0 0.0; 0.0 0.0 0.0 0.0 0.0; 0.0 0.0 0.0 0.0 0.0; 0.0 0.0 0.0 0.0 0.0;;; 0.0 0.0 0.0 0.0 0.0; 0.0 0.0 0.0 0.0 0.0; 0.0 0.0 0.0 0.0 0.0; 0.0 0.0 0.0 0.0 0.0;;;; 1.0 2.0 3.0 4.0 5.0; 1.0 2.0 3.0 4.0 5.0; 1.0 2.0 3.0 4.0 5.0; 1.0 2.0 3.0 4.0 5.0;;; 1.0 2.0 3.0 4.0 5.0; 1.0 2.0 3.0 4.0 5.0; 1.0 2.0 3.0 4.0 5.0; 1.0 2.0 3.0 4.0 5.0;;; 1.0 2.0 3.0 4.0 5.0; 1.0 2.0 3.0 4.0 5.0; 1.0 2.0 3.0 4.0 5.0; 1.0 2.0 3.0 4.0 5.0;;; 1.0 2.0 3.0 4.0 5.0; 1.0 2.0 3.0 4.0 5.0; 1.0 2.0 3.0 4.0 5.0; 1.0 2.0 3.0 4.0 5.0;;; 1.0 2.0 3.0 4.0 5.0; 1.0 2.0 3.0 4.0 5.0; 1.0 2.0 3.0 4.0 5.0; 1.0 2.0 3.0 4.0 5.0;;; 1.0 2.0 3.0 4.0 5.0; 1.0 2.0 3.0 4.0 5.0; 1.0 2.0 3.0 4.0 5.0; 1.0 2.0 3.0 4.0 5.0]
+            @test z ≈ [0.0 0.0 0.0 0.0 0.0; 0.0 0.0 0.0 0.0 0.0; 0.0 0.0 0.0 0.0 0.0; 0.0 0.0 0.0 0.0 0.0;;; 0.0 0.0 0.0 0.0 0.0; 0.0 0.0 0.0 0.0 0.0; 0.0 0.0 0.0 0.0 0.0; 0.0 0.0 0.0 0.0 0.0;;; 0.0 0.0 0.0 0.0 0.0; 0.0 0.0 0.0 0.0 0.0; 0.0 0.0 0.0 0.0 0.0; 0.0 0.0 0.0 0.0 0.0;;; 0.0 0.0 0.0 0.0 0.0; 0.0 0.0 0.0 0.0 0.0; 0.0 0.0 0.0 0.0 0.0; 0.0 0.0 0.0 0.0 0.0;;; 0.0 0.0 0.0 0.0 0.0; 0.0 0.0 0.0 0.0 0.0; 0.0 0.0 0.0 0.0 0.0; 0.0 0.0 0.0 0.0 0.0;;; 0.0 0.0 0.0 0.0 0.0; 0.0 0.0 0.0 0.0 0.0; 0.0 0.0 0.0 0.0 0.0; 0.0 0.0 0.0 0.0 0.0;;;; 1.0 1.0 1.0 1.0 1.0; 2.0 2.0 2.0 2.0 2.0; 3.0 3.0 3.0 3.0 3.0; 4.0 4.0 4.0 4.0 4.0;;; 1.0 1.0 1.0 1.0 1.0; 2.0 2.0 2.0 2.0 2.0; 3.0 3.0 3.0 3.0 3.0; 4.0 4.0 4.0 4.0 4.0;;; 1.0 1.0 1.0 1.0 1.0; 2.0 2.0 2.0 2.0 2.0; 3.0 3.0 3.0 3.0 3.0; 4.0 4.0 4.0 4.0 4.0;;; 1.0 1.0 1.0 1.0 1.0; 2.0 2.0 2.0 2.0 2.0; 3.0 3.0 3.0 3.0 3.0; 4.0 4.0 4.0 4.0 4.0;;; 1.0 1.0 1.0 1.0 1.0; 2.0 2.0 2.0 2.0 2.0; 3.0 3.0 3.0 3.0 3.0; 4.0 4.0 4.0 4.0 4.0;;; 1.0 1.0 1.0 1.0 1.0; 2.0 2.0 2.0 2.0 2.0; 3.0 3.0 3.0 3.0 3.0; 4.0 4.0 4.0 4.0 4.0]
+        end
+    end
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2,4 +2,5 @@ for testscript in ("serialtests.jl", "gencodetests.jl")
     include(testscript)
 end
 
-run(`mpirun -n 2 julia mpitests.jl`)
+run(`mpirun -n 2 julia mpitests_2ranks.jl`)
+run(`mpirun -n 4 julia mpitests_4ranks.jl`)


### PR DESCRIPTION
This PR is specific to the time function.  However, some of these changes should probably propagate to the MPI arrays for functions and sparse time functions.  But, I figure we can leave that work for future PRs.