### PR TITLE
FIx install

### DIFF
--- a/.github/workflows/Tests.yml
+++ b/.github/workflows/Tests.yml
@@ -1,34 +1,58 @@
 name: Tests
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 on: [push, pull_request]
 
 jobs:
   test:
     runs-on: ${{ matrix.os }}
+
     strategy:
+      # Prevent all build to stop if a single one fails
+      fail-fast: false
       matrix:
-        julia-version: [1.6, 1.7]
+        julia-version: [1.6, 1.7, 1.8, 1.9]
         os: [ubuntu-latest]
+        pro: ['devito', 'devitopro']
+
     steps:
       - uses: actions/checkout@v1.0.0
+  
       - uses: julia-actions/setup-julia@latest
         with:
           version: ${{ matrix.julia-version }}
+
+      - name: Setup devitopro
+        if: matrix.pro == 'devitopro'
+        run: |
+          echo "DEVITO_PRO=${{ secrets.DEVITOPRO }}" >> $GITHUB_ENV
+
       - name: install mpi
         run: sudo apt-get update
+
       - run: sudo apt-get install -y mpich
+
       - name: download miniconda manually
         run: wget https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh
+
       - name: run install
         run: bash Miniconda3-latest-Linux-x86_64.sh -b -p ~/miniconda
+
       - name: run path export
         run: export PATH=~/miniconda/bin:${PATH}
+      
       - run: julia --color=yes --project -e 'using Pkg; if VERSION >= v"1.1.0-rc1"; Pkg.build(verbose=true); else Pkg.build(); end'
         shell: bash
         env:
           PYTHON: '~/miniconda/bin/python3'
+      
       - run: julia --color=yes --check-bounds=yes --inline=yes --project -e 'using Pkg; Pkg.test(coverage=true)'
+
       - uses: julia-actions/julia-processcoverage@v1
+
       - uses: codecov/codecov-action@v1
         with:
           file: lcov.info

--- a/deps/build.jl
+++ b/deps/build.jl
@@ -4,18 +4,16 @@ dpro_repo = get(ENV, "DEVITO_PRO", "")
 which_devito = get(ENV,"DEVITO_BRANCH", "")
 try
     Conda.pip_interop(true)
-    if which_devito != ""
+    # optional devito pro installation
+    if dpro_repo != ""
+        Conda.pip("install", "git+$(dpro_repo)")
+    elseif which_devito != ""
         @info "Building devito from branch $(which_devito)"
         Conda.pip("install", "devito[tests,extras,mpi]@git+https://github.com/devitocodes/devito@$(which_devito)")
     else
         @info "Building devito from latest release"
         Conda.pip("install", "devito[tests,extras,mpi]")
     end
-    # optional devito pro installation
-    if dpro_repo != ""
-        Conda.pip("install","git+$(dpro_repo)")
-    end
-
 catch e
     if get(ENV, "JULIA_REGISTRYCI_AUTOMERGE", "false") == "true"
         @warn "unable to build"

--- a/deps/build.jl
+++ b/deps/build.jl
@@ -7,6 +7,8 @@ try
     # optional devito pro installation
     if dpro_repo != ""
         Conda.pip("install", "git+$(dpro_repo)")
+        # Currently separate as very platform dependent
+        Conda.pip("install", "mpi4py")
     elseif which_devito != ""
         @info "Building devito from branch $(which_devito)"
         Conda.pip("install", "devito[tests,extras,mpi]@git+https://github.com/devitocodes/devito@$(which_devito)")

--- a/src/Devito.jl
+++ b/src/Devito.jl
@@ -8,7 +8,7 @@ const devito = PyNULL()
 const devitopro = PyNULL()
 const seismic = PyNULL()
 
-has_devitopro() = get(ENV, "DEVITO_PRO", "") != ""
+has_devitopro() = haskey(PyCall.Conda._installed_packages_dict(), "devitopro")
 
 function __init__()
     try


### PR DESCRIPTION
- Fix install of devito as a devitpro submodule when pro is installed
- add julia 1.8 and 1.9
- add devitpro test.

You will need to setup a secret `DEVITOPRO` with your credentials:

`https://username:PAT@github.com/devitocodespro/devitopro-chevron`

All installs correctly and pass all tests on my side ( i get a weird failure with 1.7 not sure why but overall what you want):

https://github.com/mloubout/Devito.jl/actions/runs/6880780473

And from the log does install pro correctly

Installing collected packages: devitopro