### PR TITLE
modify Mod function, fix UT

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Devito"
 uuid = "06ed14b1-0e40-4084-abdf-764a285f8c42"
 authors = ["Sam Kaplan <Sam.Kaplan@chevron.com>"]
-version = "0.15.4"
+version = "0.15.5"
 
 [deps]
 MPI = "da04e1cc-30fd-572f-bb4f-1f8673147195"

--- a/src/Devito.jl
+++ b/src/Devito.jl
@@ -1992,7 +1992,7 @@ end
 
 Perform Modular division on a dimension
 """
-Mod(x::AbstractDimension,y::Int) = sympy.Mod(PyObject(x),PyObject(y))
+Mod(x::Union{AbstractDimension,PyObject},y::Int) = sympy.Mod(PyObject(x),PyObject(y))
 export Mod
 
 """Get symbolic representation for function index object"""

--- a/test/csymbolicstests.jl
+++ b/test/csymbolicstests.jl
@@ -16,5 +16,5 @@ end
     dref = Deref(f)
     @test getproperty(PyObject(dref), :_op) == "*"
     cst  = Cast(f, "char *")
-    @test getproperty(PyObject( cst), :_op) == "(char *)"
+    @test getproperty(PyObject( cst), :_op) == "(char*)"
 end

--- a/test/devitoprotests.jl
+++ b/test/devitoprotests.jl
@@ -141,7 +141,7 @@ end
         # check to make sure header is in the program
         @test occursin("#include \"stdio.h\"\n", code)
         # check to make sure the printf statement is in the program
-        @test occursin("printf(\"hello world!\" );\n", code)
+        @test occursin("printf( \"hello world!\" );\n", code)
         # test to make sure the operator compiles and runs
         @test try apply(printingop)
             true


### PR DESCRIPTION
Modify the input argument type of `Mod` function to handle `PyObject` type.
Fix two unit tests for `CCall` with `printf` and Unary Ops.