### PR TITLE
move pydef to utils for pickling

### DIFF
--- a/src/Devito.jl
+++ b/src/Devito.jl
@@ -795,11 +795,7 @@ function SparseFunction(o::PyObject)
 end
 
 function CoordSlowSparseFunction(args...; kwargs...)
-    @pydef mutable struct coordslowsparse <: devito.SparseFunction
-    
-        _sparse_position = 0
-    end
-    return SparseFunction(coordslowsparse(args...; reversedims(kwargs)...))
+    return SparseFunction(utils."coordslowsparse"(args...; reversedims(kwargs)...))
 end
 
 PyCall.PyObject(x::DiscreteFunction) = x.o

--- a/src/utils.py
+++ b/src/utils.py
@@ -10,7 +10,8 @@ except ImportError:
     Disk = None
 
 
-__all__ = ['serializedtimefunc', 'str2path', 'indexobj', 'ccode', 'subdom']
+__all__ = ['serializedtimefunc', 'str2path', 'indexobj', 'ccode', 'subdom',
+           'coordslowsparse']
 
 
 def serializedtimefunc(**kwargs):
@@ -47,3 +48,8 @@ class subdom(SubDomain):
             defines[d] = i
         
         return defines
+
+
+class coordslowsparse(SparseFunction):
+
+        _sparse_position = 0


### PR DESCRIPTION
Needs:

https://github.com/devitocodes/devito/pull/2725.

Fixes issue with sparsefirst + decoupler that uses pickling:
- Above oss pr fix pickling
- Moving the `pydef` to `utils.py` allows for its class definition to be available on the mpi workers through propagation of the python __main__ module similar to subdomain