### PR TITLE
Invalidate Python import caches after pip install

### DIFF
--- a/deps/build.jl
+++ b/deps/build.jl
@@ -85,6 +85,10 @@ try
         mpi4py("$(dir)/submodules/devito/")
         rm(dir, recursive=true, force=true)
 
+        # Invalidate Python's import caches so newly pip-installed packages
+        # are visible to the already-running interpreter.
+        py"import importlib; importlib.invalidate_caches()"
+
         # Make sure it imports
         pyimport("devitopro")
         pyimport("devito")
@@ -98,6 +102,11 @@ try
             pip("devito[extras,tests]")
             mpi4py("https://raw.githubusercontent.com/devitocodes/devito/main/")
         end
+
+        # Invalidate Python's import caches so newly pip-installed packages
+        # are visible to the already-running interpreter.
+        py"import importlib; importlib.invalidate_caches()"
+
         # Make sure it imports
         pyimport("devito")
     end


### PR DESCRIPTION
Add `importlib.invalidate_caches()` before `pyimport` checks in both the devitopro and devito-only install paths. This ensures the already-running Python interpreter sees newly pip-installed packages on disk.

This is safe: it only clears the in-process directory listing cache used by Python's import machinery. It does not affect already-loaded modules, filesystem caches, or `.pyc` files. The only effect is a negligible one-time cost to re-scan directories on the next import.